### PR TITLE
Add documentation to question_extrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Quiz-System
+
+This repository contains multiple components used for creating quizzes.
+The `question_extrator` package (see [`question_extrator/`](question_extrator))
+turns raw exam text into structured objects and ships with a set of unit tests.
+

--- a/question_extrator/README.md
+++ b/question_extrator/README.md
@@ -1,0 +1,29 @@
+# question_extrator
+
+`question_extrator` is a small library for turning plain text questions
+and their answers into structured objects.  The project was extracted from
+`Quiz-System` and exposes utilities to parse questions, answers and to
+prepare fully annotated question objects.
+
+## Features
+
+* **ParserQuestion** – splits raw text into questions and choices.
+* **ParserCorrectlyOptions** – reads an answer key and maps each
+  question number to the correct option letter.
+* **QuestionPrepare** – combines questions with the answer key producing
+  `QuestionType` objects with `OptionType` entries marked as correct.
+
+All data models are Pydantic models located in `question_extrator/types`.
+
+## Running the tests
+
+The test suite is written with `pytest`.  From the `question_extrator`
+folder run:
+
+```bash
+pytest
+```
+
+`pytest-cov` is listed as a development dependency so coverage information
+is generated when the plugin is available.
+


### PR DESCRIPTION
## Summary
- create README for `question_extrator` explaining modules and tests
- update top-level README to mention the subproject

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov=question_extrator)*

------
https://chatgpt.com/codex/tasks/task_e_687c522761688321b1e480c867f4aeb9